### PR TITLE
feat: add foreach_struct() function

### DIFF
--- a/src/foreach.cairo
+++ b/src/foreach.cairo
@@ -40,3 +40,39 @@ func foreach_loop{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_
     foreach_loop(func_pc, array_len - 1, array + 1)
     return ()
 end
+
+# The foreach_struct() method executes a provided function once for each array element. Unlike foreach(), the array can be an array of structs.
+# The provided function must have this signature exactly (including implicit params): func whatever{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(el : felt*)
+func foreach_struct{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    func_label_value : codeoffset, array_len : felt, array : felt*, element_size : felt
+):
+    let (func_pc) = get_label_location(func_label_value)
+    foreach_struct_loop(func_pc, array_len, array, element_size)
+    return ()
+end
+
+func foreach_struct_loop{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    func_pc : felt, array_len : felt, array : felt*, element_size : felt
+):
+    if array_len == 0:
+        return ()
+    end
+
+    # Put function arguments in appropriate memory cells
+    [ap] = syscall_ptr; ap++
+    [ap] = pedersen_ptr; ap++
+    [ap] = range_check_ptr; ap++
+    [ap] = array; ap++
+
+    # Call the function
+    call abs func_pc
+
+    # Update implicit parameters
+    let syscall_ptr : felt* = cast([ap - 3], felt*)
+    let pedersen_ptr : HashBuiltin* = cast([ap - 2], HashBuiltin*)
+    let range_check_ptr = [ap - 1]
+
+    # Process next element
+    foreach_struct_loop(func_pc, array_len - 1, array + element_size, element_size)
+    return ()
+end


### PR DESCRIPTION
Add a new version of the foreach that supports arrays of structs.
The user must provide a function with a signature like (note the element is a pointer):
```cairo
func inc_counter_foo{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(el : felt*)
```

You can retrieve the struct by doing:
```cairo
let foo : Foo = [cast(el, Foo*)]
```

Example:
```cairo
struct Foo:
    member x : felt
    member y : felt
end

func inc_counter_foo{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(el : felt*):
    let foo : Foo = [cast(el, Foo*)]

    let (count_x) = counter_x.read()
    counter_x.write(count_x + foo.x)

    let (count_y) = counter_y.read()
    counter_y.write(count_y + foo.y)
    return ()
end
```

Usage:
```cairo
foreach_struct(inc_counter_foo, 4, array, Foo.SIZE)
```